### PR TITLE
Add team statistics

### DIFF
--- a/app/assets/stylesheets/competitions/statistics.scss
+++ b/app/assets/stylesheets/competitions/statistics.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Competitions::Statistics controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/competitions/statistics_controller.rb
+++ b/app/controllers/competitions/statistics_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Competitions
+  # Controller for statistics of a given competition
+  class StatisticsController < BaseController
+    # GET /competitions/:id/statistics
+    def index
+      @goals_for = @competition.competition_teams.index_with(&:goals_for).sort_by { |_, goals| -goals }
+      @goals_against = @competition.competition_teams.index_with(&:goals_against).sort_by { |_, goals| goals }
+      @goal_differential = @competition.competition_teams.index_with(&:goal_differential).sort_by { |_, goals| -goals }
+    end
+  end
+end

--- a/app/models/competition_stage.rb
+++ b/app/models/competition_stage.rb
@@ -24,6 +24,7 @@
 #
 class CompetitionStage < ApplicationRecord
   belongs_to :competition
+  has_many :fixtures, foreign_key: :stage, inverse_of: :stage, dependent: :destroy
 
   def name
     case I18n.locale

--- a/app/models/competition_team.rb
+++ b/app/models/competition_team.rb
@@ -21,8 +21,20 @@
 #  team_id         (team_id => teams.id)
 #
 class CompetitionTeam < ApplicationRecord
+  include TeamStatistics
+
   belongs_to :competition
   belongs_to :team
 
   delegate :name, :short_name, :home_matches, :away_matches, to: :team
+
+  # override TeamStatistics#home_matches
+  def home_matches(_section = nil)
+    team.home_matches.joins(:fixture).where(fixture: { stage: competition.stages })
+  end
+
+  # override TeamStatistics#away_matches
+  def away_matches(_section = nil)
+    team.away_matches.joins(:fixture).where(fixture: { stage: competition.stages })
+  end
 end

--- a/app/models/concerns/team_statistics.rb
+++ b/app/models/concerns/team_statistics.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# Match statistics for team
+module TeamStatistics
+  extend ActiveSupport::Concern
+
+  # should be implemented by model including this module
+  def home_matches
+    raise NotImplementedError
+  end
+
+  # should be implemented by model including this module
+  def away_matches
+    raise NotImplementedError
+  end
+
+  def matches(section = nil)
+    home_matches(section) + away_matches(section)
+  end
+
+  def home_wins(section = nil)
+    home_matches(section).where('home_score > away_score')
+  end
+
+  def home_losses(section = nil)
+    home_matches(section).where('home_score < away_score')
+  end
+
+  def home_draws(section = nil)
+    home_matches(section).where('home_score = away_score')
+  end
+
+  def away_wins(section = nil)
+    away_matches(section).where('away_score > home_score')
+  end
+
+  def away_losses(section = nil)
+    away_matches(section).where('away_score < home_score')
+  end
+
+  def away_draws(section = nil)
+    away_matches(section).where('away_score = home_score')
+  end
+
+  def wins(section = nil)
+    home_wins(section) + away_wins(section)
+  end
+
+  def losses(section = nil)
+    home_losses(section) + away_losses(section)
+  end
+
+  def draws(section = nil)
+    home_draws(section) + away_draws(section)
+  end
+
+  def home_goals_for(section = nil)
+    home_matches(section).pluck(:home_score).compact.sum
+  end
+
+  def home_goals_against(section = nil)
+    home_matches(section).pluck(:away_score).compact.sum
+  end
+
+  def away_goals_for(section = nil)
+    away_matches(section).pluck(:away_score).compact.sum
+  end
+
+  def away_goals_against(section = nil)
+    away_matches(section).pluck(:home_score).compact.sum
+  end
+
+  def points(section = nil)
+    (wins(section).count * 3) + draws(section).count
+  end
+
+  def goals_for(section = nil)
+    home_goals_for(section) + away_goals_for(section)
+  end
+
+  def goals_against(section = nil)
+    home_goals_against(section) + away_goals_against(section)
+  end
+
+  def goal_differential(section = nil)
+    goals_for(section) - goals_against(section)
+  end
+end

--- a/app/models/fixture.rb
+++ b/app/models/fixture.rb
@@ -26,6 +26,8 @@
 #
 class Fixture < ApplicationRecord
   belongs_to :stage, class_name: 'CompetitionStage', optional: true
+  has_one :competition, through: :stage
+  has_one :competition_series, through: :competition, source: :series
   has_many :matches, dependent: :destroy
 
   def name

--- a/app/models/group_team.rb
+++ b/app/models/group_team.rb
@@ -21,88 +21,20 @@
 #  team_id   (team_id => competition_teams.id)
 #
 class GroupTeam < ApplicationRecord
+  include TeamStatistics
+
   belongs_to :group, class_name: 'LeagueGroup'
   belongs_to :team, class_name: 'CompetitionTeam'
 
   delegate :name, :short_name, to: :team
 
-  def home_matches
-    team.home_matches.joins(:fixture).where(fixture: { stage: group.league })
+  # override TeamStatistics#home_matches
+  def home_matches(section = nil)
+    team.home_matches.joins(:fixture).where(fixture: group.league.fixtures.merge(Matchday.section_n(section)))
   end
 
-  def away_matches
-    team.away_matches.joins(:fixture).where(fixture: { stage: group.league })
-  end
-
-  def matches
-    home_matches + away_matches
-  end
-
-  def home_wins(section = nil)
-    home_matches.where('home_score > away_score').where(fixture: Matchday.section_n(section))
-  end
-
-  def home_losses(section = nil)
-    home_matches.where('home_score < away_score').where(fixture: Matchday.section_n(section))
-  end
-
-  def home_draws(section = nil)
-    home_matches.where('home_score = away_score').where(fixture: Matchday.section_n(section))
-  end
-
-  def away_wins(section = nil)
-    away_matches.where('away_score > home_score').where(fixture: Matchday.section_n(section))
-  end
-
-  def away_losses(section = nil)
-    away_matches.where('away_score < home_score').where(fixture: Matchday.section_n(section))
-  end
-
-  def away_draws(section = nil)
-    away_matches.where('away_score = home_score').where(fixture: Matchday.section_n(section))
-  end
-
-  def wins(section = nil)
-    home_wins(section) + away_wins(section)
-  end
-
-  def losses(section = nil)
-    home_losses(section) + away_losses(section)
-  end
-
-  def draws(section = nil)
-    home_draws(section) + away_draws(section)
-  end
-
-  def home_goals_for(section = nil)
-    home_matches.where(fixture: Matchday.section_n(section)).pluck(:home_score).compact.sum
-  end
-
-  def home_goals_against(section = nil)
-    home_matches.where(fixture: Matchday.section_n(section)).pluck(:away_score).compact.sum
-  end
-
-  def away_goals_for(section = nil)
-    away_matches.where(fixture: Matchday.section_n(section)).pluck(:away_score).compact.sum
-  end
-
-  def away_goals_against(section = nil)
-    away_matches.where(fixture: Matchday.section_n(section)).pluck(:home_score).compact.sum
-  end
-
-  def points(section = nil)
-    (wins(section).count * 3) + draws(section).count
-  end
-
-  def goals_for(section = nil)
-    home_goals_for(section) + away_goals_for(section)
-  end
-
-  def goals_against(section = nil)
-    home_goals_against(section) + away_goals_against(section)
-  end
-
-  def goal_differential(section = nil)
-    goals_for(section) - goals_against(section)
+  # override TeamStatistics#away_matches
+  def away_matches(section = nil)
+    team.away_matches.joins(:fixture).where(fixture: group.league.fixtures.merge(Matchday.section_n(section)))
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -46,6 +46,9 @@ class Match < ApplicationRecord
   belongs_to :venue
   belongs_to :winner_next_match, class_name: 'Match', optional: true
   belongs_to :loser_next_match, class_name: 'Match', optional: true
+  has_one :stage, through: :fixture
+  has_one :competition, through: :stage
+  has_one :competition_series, through: :competition, source: :series
   has_many :winner_previous_matches, class_name: 'Match', dependent: :nullify
   has_many :loser_previous_matches, class_name: 'Match', dependent: :nullify
 

--- a/app/models/matchday.rb
+++ b/app/models/matchday.rb
@@ -26,4 +26,14 @@
 #
 class Matchday < Fixture
   scope :section_n, ->(n) { where(order: ..(n.presence || Float::INFINITY)) }
+
+  # override Fixture#name
+  def name
+    super || I18n.t('activerecord.attributes.matchday.name', number: order)
+  end
+
+  # override Fixture#short_name
+  def short_name
+    super || I18n.t('activerecord.attributes.matchday.short_name', number: order)
+  end
 end

--- a/app/views/competition_series/index.html.erb
+++ b/app/views/competition_series/index.html.erb
@@ -1,4 +1,8 @@
 <h1><%= I18n.t('activerecord.models.competition_series') %></h1>
+<div>
+  <%= link_to 'Home', home_path %>
+  <%= " > #{I18n.t('activerecord.models.competition_series')}"%>
+<div>
 <ul>
     <% @competition_series.each do |series| %>
         <li>

--- a/app/views/competition_series/index.html.erb
+++ b/app/views/competition_series/index.html.erb
@@ -6,10 +6,7 @@
 <ul>
     <% @competition_series.each do |series| %>
         <li>
-            <a href="/competition_series/<%= series.id %>">
-            <p>
-                <%= series.name %>
-            </p>
+            <%= link_to series.name, competition_series_path(series) %>
         </li>
     <% end %>
 </ul>

--- a/app/views/competition_series/show.html.erb
+++ b/app/views/competition_series/show.html.erb
@@ -8,10 +8,7 @@
 <ul>
     <% @competition_series.iterations.order(:start_year).each do |iteration| %>
         <li>
-            <a href="/competitions/<%= iteration.id %>">
-            <p>
-                <%= iteration.name %>
-            </p>
+            <%= link_to iteration.name, competition_path(iteration) %>
         </li>
     <% end %>
 </ul>

--- a/app/views/competition_series/show.html.erb
+++ b/app/views/competition_series/show.html.erb
@@ -1,4 +1,10 @@
 <h1><%= @competition_series.name %></h1>
+<div>
+  <%= link_to 'Home', home_path %>
+  <%= ' > ' %>
+  <%= link_to I18n.t('activerecord.models.competition_series'), competition_series_list_path %>
+  <%= " > #{@competition_series.name}"%>
+<div>
 <ul>
     <% @competition_series.iterations.order(:start_year).each do |iteration| %>
         <li>

--- a/app/views/competitions/fixtures/index.html.erb
+++ b/app/views/competitions/fixtures/index.html.erb
@@ -9,43 +9,29 @@
   <%= link_to @competition.name, competition_path(@competition) %>
   <%= " > #{I18n.t('pages.fixtures.title')}" %>
 <div>
-<% if @competition.stages.count == 1 %>
-    <ul>
-        <% @competition.stages.first.matchdays.order(:order).each do |fixture| %>
-            <li>
-                <a href="/fixtures/<%= fixture.id %>">
-                    <p><%= fixture.name %></p>
-                </a>
-            </li>
-        <% end %>
-    </ul>
-<% else %>
-    <ul>
-        <% @competition.stages.each do |stage| %>
-            <li>
-                <p><%= stage.name %></p>
-                <% if stage.is_a?(LeagueStage) %>
-                    <ul>
-                        <% stage.matchdays.each do |matchday| %>
-                            <li>
-                                <a href="/fixtures/<%= matchday.id%>">
-                                    <p><%= matchday.name %></p>
-                                </a>
-                            </li>
-                        <% end %>
-                    </ul>
-                <% else %>
-                    <ul>
-                        <% stage.rounds.each do |round| %>
-                            <li>
-                                <a href="/fixtures/<%= round.id %>">
-                                    <p><%= round.name %>
-                                </a>
-                            </li>
-                        <% end %>
-                    </ul>
-                <% end %>
-            </li>
-        <% end %>
-    </ul>
-<% end %>
+<ul>
+    <% @competition.stages.each do |stage| %>
+        <li>
+            <% if @competition.stages.count > 1%>
+                <%= stage.name %>
+            <% end %>
+            <% if stage.is_a?(LeagueStage) %>
+                <ul>
+                    <% stage.matchdays.each do |matchday| %>
+                        <li>
+                            <%= link_to matchday.name, fixture_path(matchday) %>
+                        </li>
+                    <% end %>
+                </ul>
+            <% else %>
+                <ul>
+                    <% stage.rounds.each do |round| %>
+                        <li>
+                            <%= link_to round.name, fixture_path(round) %>
+                        </li>
+                    <% end %>
+                </ul>
+            <% end %>
+        </li>
+    <% end %>
+</ul>

--- a/app/views/competitions/fixtures/index.html.erb
+++ b/app/views/competitions/fixtures/index.html.erb
@@ -1,4 +1,14 @@
 <h1><%= @competition.name %></h1>
+<div>
+  <%= link_to 'Home', home_path %>
+  <%= ' > ' %>
+  <%= link_to I18n.t('activerecord.models.competition_series'), competition_series_list_path %>
+  <%= ' > ' %>
+  <%= link_to @competition.series.name, competition_series_path(@competition.series) %>
+  <%= ' > ' %>
+  <%= link_to @competition.name, competition_path(@competition) %>
+  <%= " > #{I18n.t('pages.fixtures.title')}" %>
+<div>
 <% if @competition.stages.count == 1 %>
     <ul>
         <% @competition.stages.first.matchdays.order(:order).each do |fixture| %>

--- a/app/views/competitions/results/index.html.erb
+++ b/app/views/competitions/results/index.html.erb
@@ -1,4 +1,14 @@
 <h1><%= I18n.t('pages.results.title') %></h1>
+<div>
+  <%= link_to 'Home', home_path %>
+  <%= ' > ' %>
+  <%= link_to I18n.t('activerecord.models.competition_series'), competition_series_list_path %>
+  <%= ' > ' %>
+  <%= link_to @competition.series.name, competition_series_path(@competition.series) %>
+  <%= ' > ' %>
+  <%= link_to @competition.name, competition_path(@competition) %>
+  <%= " > #{I18n.t('pages.results.title')}" %>
+<div>
 <p> <%= @winner.name %> 優勝おめでとうございます！</p>
 <% if @competition.stages.count == 1 %>
     <ol>

--- a/app/views/competitions/results/index.html.erb
+++ b/app/views/competitions/results/index.html.erb
@@ -10,51 +10,43 @@
   <%= " > #{I18n.t('pages.results.title')}" %>
 <div>
 <p> <%= @winner.name %> 優勝おめでとうございます！</p>
-<% if @competition.stages.count == 1 %>
-    <ol>
-        <% @competition.stages.first.groups.first.standings.each do |team| %>
-            <li>
-                <p><%= team.name %></p>
-            </li>
-        <% end %>
-    </ol>
-<% else %>
-    <ul>
-        <% @competition.stages.each do |stage| %>
-            <li>
-                <p><%= stage.name %></p>
-                <% if stage.is_a?(LeagueStage) %>
-                    <ul>
-                        <% stage.groups.each do |group| %>
-                            <li>
-                                <p><%= group.name %></p>
-                                <ol>
-                                    <% group.standings.each do |team| %>
-                                        <li>
-                                            <p><%= team.name %></p>
-                                        </li>
-                                    <% end %>
-                                </ol>
-                            </li>
-                        <% end %>
-                    </ul>
-                <% else %>
-                    <ul>
-                        <% stage.rounds.each do |round| %>
-                            <li>
-                                <p><%= round.name %></p>
-                                <ul>
-                                    <% round.winners.each do |team| %>
-                                        <li>
-                                            <p><%= team.name %></p>
-                                        </li>
-                                    <% end %>
-                                </ul>
-                            </li>
-                        <% end %>
-                    </ul>
-                <% end %>
-            </li>
-        <% end %>
-    </ul>
-<% end %>
+<ul>
+    <% @competition.stages.each do |stage| %>
+        <li>
+            <% if @competition.stages.count > 1%>
+                <%= stage.name %>
+            <% end %>
+            <% if stage.is_a?(LeagueStage) %>
+                <ul>
+                    <% stage.groups.each do |group| %>
+                        <li>
+                            <%= group.name %>
+                            <ol>
+                                <% group.standings.each do |team| %>
+                                    <li>
+                                        <%= team.name %>
+                                    </li>
+                                <% end %>
+                            </ol>
+                        </li>
+                    <% end %>
+                </ul>
+            <% else %>
+                <ul>
+                    <% stage.rounds.each do |round| %>
+                        <li>
+                            <%= round.name %>
+                            <ul>
+                                <% round.winners.each do |team| %>
+                                    <li>
+                                        <%= team.name %>
+                                    </li>
+                                <% end %>
+                            </ul>
+                        </li>
+                    <% end %>
+                </ul>
+            <% end %>
+        </li>
+    <% end %>
+</ul>

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -10,4 +10,9 @@
             <p><%= I18n.t('pages.results.title') %></p>
         </a>
     </li>
+    <li>
+        <a href="/competitions/<%= @competition.id %>/statistics">
+            <p><%= I18n.t('pages.statistics.title') %></p>
+        </a>
+    </li>
 </ul>

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -9,18 +9,12 @@
 <div>
 <ul>
     <li>
-        <a href="/competitions/<%= @competition.id %>/fixtures">
-            <p><%= I18n.t('pages.fixtures.title') %></p>
-        </a>
+        <%= link_to I18n.t('pages.fixtures.title'), competition_fixtures_path(@competition) %>
     </li>
     <li>
-        <a href="/competitions/<%= @competition.id %>/results">
-            <p><%= I18n.t('pages.results.title') %></p>
-        </a>
+        <%= link_to I18n.t('pages.results.title'), competition_results_path(@competition) %>
     </li>
     <li>
-        <a href="/competitions/<%= @competition.id %>/statistics">
-            <p><%= I18n.t('pages.statistics.title') %></p>
-        </a>
+        <%= link_to I18n.t('pages.statistics.title'), competition_statistics_path(@competition) %>
     </li>
 </ul>

--- a/app/views/competitions/show.html.erb
+++ b/app/views/competitions/show.html.erb
@@ -1,4 +1,12 @@
 <h1><%= @competition.name %></h1>
+<div>
+  <%= link_to 'Home', home_path %>
+  <%= ' > ' %>
+  <%= link_to I18n.t('activerecord.models.competition_series'), competition_series_list_path %>
+  <%= ' > ' %>
+  <%= link_to @competition.series.name, competition_series_path(@competition.series) %>
+  <%= " > #{@competition.name}" %>
+<div>
 <ul>
     <li>
         <a href="/competitions/<%= @competition.id %>/fixtures">

--- a/app/views/competitions/statistics/index.html.erb
+++ b/app/views/competitions/statistics/index.html.erb
@@ -1,4 +1,14 @@
 <h1><%= I18n.t('pages.statistics.title') %></h1>
+<div>
+  <%= link_to 'Home', home_path %>
+  <%= ' > ' %>
+  <%= link_to I18n.t('activerecord.models.competition_series'), competition_series_list_path %>
+  <%= ' > ' %>
+  <%= link_to @competition.series.name, competition_series_path(@competition.series) %>
+  <%= ' > ' %>
+  <%= link_to @competition.name, competition_path(@competition) %>
+  <%= " > #{I18n.t('pages.statistics.title')}" %>
+<div>
 <p><%= I18n.t('dictionary.goals_for') %></p>
 <ol>
     <% @goals_for.each do |team, goals| %>

--- a/app/views/competitions/statistics/index.html.erb
+++ b/app/views/competitions/statistics/index.html.erb
@@ -1,0 +1,27 @@
+<h1><%= I18n.t('pages.statistics.title') %></h1>
+<p><%= I18n.t('dictionary.goals_for') %></p>
+<ol>
+    <% @goals_for.each do |team, goals| %>
+        <li>
+            <p><%= team.name %>: <%= goals %></p>
+        </li>
+    <% end %>
+</ol>
+<br />
+<p><%= I18n.t('dictionary.goals_against') %></p>
+<ol>
+    <% @goals_against.each do |team, goals| %>
+        <li>
+            <p><%= team.name %>: <%= goals %></p>
+        </li>
+    <% end %>
+</ol>
+<br />
+<p><%= I18n.t('dictionary.goal_differential') %></p>
+<ol>
+    <% @goal_differential.each do |team, goals| %>
+        <li>
+            <p><%= team.name %>: <%= goals %></p>
+        </li>
+    <% end %>
+</ol>

--- a/app/views/competitions/statistics/index.html.erb
+++ b/app/views/competitions/statistics/index.html.erb
@@ -13,7 +13,7 @@
 <ol>
     <% @goals_for.each do |team, goals| %>
         <li>
-            <p><%= team.name %>: <%= goals %></p>
+            <%= "#{team.name}: #{goals}" %>
         </li>
     <% end %>
 </ol>
@@ -22,7 +22,7 @@
 <ol>
     <% @goals_against.each do |team, goals| %>
         <li>
-            <p><%= team.name %>: <%= goals %></p>
+            <%= "#{team.name}: #{goals}" %>
         </li>
     <% end %>
 </ol>
@@ -31,7 +31,7 @@
 <ol>
     <% @goal_differential.each do |team, goals| %>
         <li>
-            <p><%= team.name %>: <%= goals %></p>
+            <%= "#{team.name}: #{goals}" %>
         </li>
     <% end %>
 </ol>

--- a/app/views/fixtures/show.html.erb
+++ b/app/views/fixtures/show.html.erb
@@ -1,4 +1,14 @@
 <h1><%= @fixture.name %></h1>
+<div>
+  <%= link_to 'Home', home_path %>
+  <%= ' > ' %>
+  <%= link_to I18n.t('activerecord.models.competition_series'), competition_series_list_path %>
+  <%= ' > ' %>
+  <%= link_to @fixture.competition_series.name, competition_series_path(@fixture.competition_series) %>
+  <%= ' > ' %>
+  <%= link_to @fixture.competition.name, competition_path(@fixture.competition) %>
+  <%= " > #{@fixture.name}" %>
+<div>
 <ul>
     <% @fixture.matches.order(:kickoff_at).each do |match| %>
         <li>

--- a/app/views/fixtures/show.html.erb
+++ b/app/views/fixtures/show.html.erb
@@ -12,9 +12,7 @@
 <ul>
     <% @fixture.matches.order(:kickoff_at).each do |match| %>
         <li>
-            <a href="/matches/<%= match.id %>">
-                <p><%= match.home_team.short_name %> v. <%= match.away_team.short_name %></p>
-            </a>
+            <%= link_to "#{match.home_team.short_name} v. #{match.away_team.short_name}", match_path(match) %>
         </li>
     <% end %>
 </ul>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,8 +2,6 @@
 <p><%= I18n.t('application.description') %></p>
 <ul>
     <li>
-        <a href='/competition_series'>
-            <p><%= I18n.t('activerecord.models.competition_series') %></p>
-        </a>
+        <%= link_to I18n.t('activerecord.models.competition_series'), competition_series_list_path %>
     </li>
 </ul>

--- a/app/views/matches/edit.html.erb
+++ b/app/views/matches/edit.html.erb
@@ -1,5 +1,4 @@
 <h1><%= I18n.t('pages.matches.edit.title') %></h1>
-
 <%= form_with model: @match do |form| %>
     <div>
         <%= form.label :home_score %>
@@ -17,3 +16,4 @@
         <%= form.submit %>
     </div>
 <% end %>
+<%= link_to I18n.t('actions.back'), match_path(@match) %>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -1,4 +1,14 @@
 <h1><%= I18n.t('activerecord.models.match') %></h1>
+<div>
+  <%= link_to 'Home', home_path %>
+  <%= ' > ' %>
+  <%= link_to I18n.t('activerecord.models.competition_series'), competition_series_list_path %>
+  <%= ' > ' %>
+  <%= link_to @match.competition_series.name, competition_series_path(@match.competition_series) %>
+  <%= ' > ' %>
+  <%= link_to @match.competition.name, competition_path(@match.competition) %>
+  <%= " > #{@match.home_team.short_name} v. #{@match.away_team.short_name}" %>
+</div>
 <p>
     <%= @match.home_team.name %> <%= @match.display_score %> <%= @match.away_team.name %>
 </p>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -9,14 +9,8 @@
   <%= link_to @match.competition.name, competition_path(@match.competition) %>
   <%= " > #{@match.home_team.short_name} v. #{@match.away_team.short_name}" %>
 </div>
-<p>
-    <%= @match.home_team.name %> <%= @match.display_score %> <%= @match.away_team.name %>
-</p>
-<p>
-    <%= I18n.l(@match.kickoff_at, format: :with_day_of_week) %>
-</p>
-<p>
-    <%= @match.venue.name %>
-</p>
+<p><%= "#{@match.home_team.name} #{@match.display_score} #{@match.away_team.name}" %></p>
+<p><%= I18n.l(@match.kickoff_at, format: :with_day_of_week) %></p>
+<p><%= @match.venue.name %></p>
 
 <%= button_to I18n.t('actions.edit'), "/matches/#{@match.id}/edit", method: :get %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,7 @@ en:
     description: Manage and view data on football matches
   actions:
     edit: Edit
+    back: Back
   date:
     formats:
       default: "%Y/%m/%d"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,9 @@ en:
       fixture: Section
       match: Match
     attributes:
+      matchday:
+        name: "Matchday %{number}"
+        short_name: "MD %{number}"
       match:
         home_score: Score (home)
         away_score: Score (away)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,10 @@ en:
       long: "%A, %B %d, %Y %H:%M:%S %z"
       short: "%y/%m/%d %H:%M"
       with_day_of_week: "%A, %B %d, %Y %H:%M"
+  dictionary:
+    goals_for: Goals For
+    goals_against: Goals Against
+    goal_differential: Goal Differential
   activerecord:
     models:
       competition_series: Competitions
@@ -33,3 +37,5 @@ en:
       title: Fixture List
     results:
       title: Results
+    statistics:
+      title: Statistics

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,6 +15,10 @@ ja:
       long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
       short: "%y/%m/%d %H:%M"
       with_day_of_week: "%Y年%m月%d日(%a) %H:%M"
+  dictionary:
+    goals_for: 得点
+    goals_against: 失点
+    goal_differential: 得失点
   activerecord:
     models:
       competition_series: 大会一覧
@@ -33,3 +37,5 @@ ja:
       title: 節一覧
     results:
       title: 結果
+    statistics:
+      title: 統計

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
     description: サッカー試合のデータ管理ツール
   actions:
     edit: 編集
+    back: 戻る
   date:
     formats:
       default: "%Y/%m/%d"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -27,6 +27,9 @@ ja:
       fixture: 節
       match: 試合
     attributes:
+      matchday:
+        name: "第%{number}節"
+        short_name: "第%{number}節"
       match:
         home_score: スコア（ホーム）
         away_score: スコア（アウェイ）

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get    'competitions/:id', to: 'competitions#show', as: :competition
   get    'competitions/:id/fixtures', to: 'competitions/fixtures#index', as: :competition_fixtures
   get    'competitions/:id/results', to: 'competitions/results#index', as: :competition_results
+  get    'competitions/:id/statistics', to: 'competitions/statistics#index', as: :competition_statistics
   get    'fixtures/:id', to: 'fixtures#show', as: :fixture
   get    'matches/:id', to: 'matches#show', as: :match
   get    'matches/:id/edit', to: 'matches#edit', as: :edit_match

--- a/scripts/onetime/20211212_import_levain_cup_2021.rb
+++ b/scripts/onetime/20211212_import_levain_cup_2021.rb
@@ -55,13 +55,7 @@ group_stage = ybc_2021.stages.find_or_create_by!(
   name_en: 'Group Stage'
 )
 (1..6).each do |i|
-  group_stage.matchdays.find_or_create_by!(
-    order: i,
-    name: "第#{i}節",
-    name_en: "Matchday #{i}",
-    name_short: "第#{i}節",
-    name_short_en: "MD#{i}"
-  )
+  group_stage.matchdays.find_or_create_by!(order: i)
 end
 
 group_a = group_stage.groups.find_or_create_by!(name: 'Aグループ', name_en: 'A Group')

--- a/test/controllers/competitions/statistics_controller_test.rb
+++ b/test/controllers/competitions/statistics_controller_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Competitions
+  class StatisticsControllerTest < ActionDispatch::IntegrationTest
+    # test "the truth" do
+    #   assert true
+    # end
+  end
+end


### PR DESCRIPTION
# Summary
- Add  page for statistics of a given competition
    - Competition winner
    - Goals for, goals against, goal differential

# Additional changes
- Move win/loss, points, goal calculation logic to concern
- Add breadcrumb navigation to all pages + minor refactoring
- [Bugfix] Fixture name is blank for league matchdays