### PR TITLE
Allow update of match status

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'react-rails', '~> 2.6'
 
 # Internationalization
 gem 'rails-i18n'
+gem 'enum_help'
 
 # Code format check
 gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
     concurrent-ruby (1.1.9)
     connection_pool (2.2.5)
     crass (1.0.6)
+    enum_help (0.0.18)
+      activesupport (>= 3.0.0)
     erubi (1.10.0)
     execjs (2.8.1)
     ffi (1.15.4)
@@ -250,6 +252,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   capybara (>= 3.26)
+  enum_help
   jbuilder (~> 2.7)
   listen (~> 3.3)
   puma (~> 5.0)

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -14,7 +14,7 @@ class MatchesController < ApplicationController
 
   # PATCH /matches/:id/edit
   def update
-    @match.update!(score_params)
+    @match.update!(match_params)
     redirect_to @match
   end
 
@@ -24,7 +24,7 @@ class MatchesController < ApplicationController
     @match = Match.find(params[:id])
   end
 
-  def score_params
-    params.require(:match).permit(:home_score, :away_score)
+  def match_params
+    params.require(:match).permit(:home_score, :away_score, :status)
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -57,10 +57,8 @@ class Match < ApplicationRecord
   enum status: { not_started: 0, in_progress: 1, halftime: 2, complete: 3, stopped: 4, postponed: 5 },
        _prefix: true
 
-  def display_score
-    return 'v.' if status_not_started? || status_postponed? || home_score.nil? || away_score.nil?
-
-    "#{home_score} - #{away_score}"
+  def score_displayable?
+    !status_not_started? && home_score.present? && away_score.present?
   end
 
   def winner

--- a/app/views/fixtures/show.html.erb
+++ b/app/views/fixtures/show.html.erb
@@ -13,6 +13,13 @@
     <% @fixture.matches.order(:kickoff_at).each do |match| %>
         <li>
             <%= link_to "#{match.home_team.short_name} v. #{match.away_team.short_name}", match_path(match) %>
+            <% if match.score_displayable? %>
+                <%= " #{match.home_score} - #{match.away_score}" %>
+            <% elsif match.status_postponed? %>
+                <%= " #{match.status_i18n}" %>
+            <% else %>
+                <%= I18n.l(match.kickoff_at, format: :with_day_of_week) %>
+            <% end %>
         </li>
     <% end %>
 </ul>

--- a/app/views/matches/edit.html.erb
+++ b/app/views/matches/edit.html.erb
@@ -13,6 +13,13 @@
     </div>
 
     <div>
+        <%= form.label :status %>
+        <br/>
+        <%= form.select :status, Match.statuses_i18n.invert %>
+    </div>
+
+    <br/>
+    <div>
         <%= form.submit %>
     </div>
 <% end %>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -9,8 +9,20 @@
   <%= link_to @match.competition.name, competition_path(@match.competition) %>
   <%= " > #{@match.home_team.short_name} v. #{@match.away_team.short_name}" %>
 </div>
-<p><%= "#{@match.home_team.name} #{@match.display_score} #{@match.away_team.name}" %></p>
-<p><%= I18n.l(@match.kickoff_at, format: :with_day_of_week) %></p>
+<p>
+  <% if @match.score_displayable? %>
+    <%= "#{@match.home_team.name} #{@match.home_score} - #{@match.away_score} #{@match.away_team.name}" %>
+  <% else %>
+    <%= "#{@match.home_team.name} v. #{@match.away_team.name}" %>
+  <% end %>
+</p>
+<p>
+  <% if @match.status_postponed? %>
+    <%= @match.status_i18n %>
+  <% else %>
+    <%= I18n.l(@match.kickoff_at, format: :with_day_of_week) %>
+  <% end %>
+</p>
 <p><%= @match.venue.name %></p>
 
 <%= button_to I18n.t('actions.edit'), "/matches/#{@match.id}/edit", method: :get %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,16 @@ en:
       match:
         home_score: Score (home)
         away_score: Score (away)
+        status: Status
+  enums:
+    match:
+      status:
+        not_started: Not Started
+        in_progress: In Progress
+        halftime: Halftime
+        complete: Complete
+        stopped: Stopped
+        postponed: Postponed
   pages:
     matches:
       edit:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -33,6 +33,16 @@ ja:
       match:
         home_score: スコア（ホーム）
         away_score: スコア（アウェイ）
+        status: ステータス
+  enums:
+    match:
+      status:
+        not_started: 試合前
+        in_progress: 試合中
+        halftime: ハーフタイム
+        complete: 試合終了
+        stopped: 試合中断
+        postponed: 試合中止
   pages:
     matches:
       edit:


### PR DESCRIPTION
# Summary
Fixes #26

# Additional changes
- Add `enum_help` gem for internationalization of enum labels
- Add match score/kickoff time/status to fixture match list
- Refactor display logic out of model
    - Details of display vary by page so it should be moved to view